### PR TITLE
Use xstate FSM to handle form route transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "webpack-dev-server": "3.1.9",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "3.6.3",
+    "xstate": "^4.3.1",
     "yup": "^0.26.6"
   },
   "scripts": {

--- a/src/components/404-route.js
+++ b/src/components/404-route.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+
+const Route404 = (props) => 
+  <Redirect to="/not-found" />;
+
+export default Route404;

--- a/src/components/fsm.js
+++ b/src/components/fsm.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import { Machine } from 'xstate';
+import { getNodes } from 'xstate/lib/graph';
+import { interpret } from 'xstate/lib/interpreter'
+
+const MachineContext = React.createContext();
+const MachineStateContext = React.createContext();
+
+const formatRouteWithDots = string =>
+  string.replace(/\//g, '.').replace('.', '');
+
+class FSMRouter extends React.Component {
+  static propTypes = {
+    config: PropTypes.object.isRequired,
+  }
+
+  routes = null
+  machine = null
+  service = null
+  machineState = null
+  historySubscriber = null
+  historyTransitioning = false
+
+  constructor(props) {
+    super(props);
+
+    const routeNodes = getNodes(Machine(props.config));
+
+    this.routes = routeNodes.reduce((routes, node) => {
+      if (node.meta && node.meta.path) {
+        // TODO: make `form` key a configurable param / option
+        routes[`/form${node.meta.path}`] = node.meta.path;
+      }
+
+      return routes;
+    }, {});
+
+    const configWithRoutes = {
+      ...props.config,
+      on: {
+        ...Object.entries(this.routes).reduce((mapped, [key, value]) => {
+          const routeToStatePath = formatRouteWithDots(key);
+
+          return {
+            ...mapped,
+            [routeToStatePath]: { target: formatRouteWithDots(value) },
+          };
+        }, {})
+      },
+    };
+
+    const machine = Machine(configWithRoutes);
+    
+    this.service = interpret(machine);
+    this.machine = machine;
+    this.machineState = machine.initialState;
+    this.service.start();
+
+    this.handleHistoryTransition(props.location);
+    this.historySubscriber = props.history.listen(this.handleHistoryTransition);
+  }
+
+  componentWillUnmount() {
+    this.historySubscriber();
+  }
+
+  hasMatchingRoute(maybeRoute) {
+    return !!this.routes[maybeRoute];
+  }
+
+  handleHistoryTransition = ({ pathname }) => {
+    if (this.hasMatchingRoute(pathname)) {
+      const machinePath = formatRouteWithDots(pathname);
+      console.log('entering handle history transition to', machinePath)
+
+      this.machineState = this.service.send(machinePath);
+    }
+  }
+
+  transition = ({ command = 'NEXT', data = {} }) => {
+    this.machineState = this.machine.transition(this.machineState, command, data);
+    
+    const path = this.machineState.tree.paths[0];
+    const currentNode = this.service.machine.getStateNodeByPath(path);
+
+    if (currentNode.meta && currentNode.meta.path) {
+      console.log('xstate trans moving to ', currentNode.meta.path)
+      this.props.history.push(`/form${currentNode.meta.path}`);
+    }    
+  }
+
+  render() {
+    return (
+      <MachineContext.Provider value={this.transition}>
+        <MachineStateContext.Provider value={this.machineState}>
+          { this.props.children }
+        </MachineStateContext.Provider>
+      </MachineContext.Provider>
+    )
+  }
+}
+
+export const MachineState = MachineStateContext.Consumer;
+export const MachineConsumer = MachineContext.Consumer
+export default withRouter(FSMRouter);

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Switch } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import { Formik, Form, connect } from 'formik';
+import Route404 from 'components/404-route';
 import Debug from './debug';
 import Button from 'components/button';
 import RouteWithSubRoutes from 'components/route-with-subroutes';
@@ -32,10 +33,7 @@ class Section extends React.Component {
   }
 
   next = (values) => {
-    this.setState(state => ({
-      step: Math.min(state.step + 1, this.getChildCount()),
-      values
-    }))
+    this.props.onNext({ data: values });
   };
 
   registerStep = (step) => {
@@ -71,7 +69,7 @@ class Section extends React.Component {
       this.props.handleSubmit(values);
     } else {
       actions.setSubmitting(false);
-      this.next();
+      this.next(values);
     }
   }
 
@@ -123,11 +121,13 @@ class Section extends React.Component {
                             sectionName: this.props.name,
                             handleChange: this.handleChange(props.handleChange),
                             registerStep: this.registerStep,
+                            handleNext: this.props.handleNext
                           }}
                         />
                       );
                     })
                   }
+                  <Route component={Route404} />
                 </Switch>
                 <div className="margin-y-2">
                   <Button disabled={disable}>
@@ -296,11 +296,13 @@ class Wizard extends React.Component {
                             handleChange,
                             values,
                             errors,
+                            onNext: this.props.onNext,
                           }}
                         />
                       );
                     })
                   }
+                  <Route component={Route404} />
                 </Switch>
                 <Debug name="Complete form state" />
               </>

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -1,0 +1,113 @@
+import { actions } from 'xstate';
+const { log } = actions;
+
+const basicInfoState = {
+  initial: 'applicant-name',
+  states: {
+    'applicant-name': {
+      on: {
+        NEXT: 'address'
+      },
+      meta: {
+        path: '/basic-info/applicant-name'
+      },
+    },
+    address: {
+      on: {
+        NEXT: 'unknown' 
+      },
+      meta: {
+        path: '/basic-info/address'
+      },
+      onEntry: () => console.log('entered address')
+    },
+    unknown: {
+      on: {
+        '': [
+          { target: 'mailing-address', cond: (context) => {
+            return !context.basicInfo.currentMailingAddress;
+          }},
+          { target: 'shortcut', cond: (context) => {
+            return context.basicInfo.currentMailingAddress;
+          }},
+        ],
+      },
+      onEntry: () => console.log('ENTER TRANSITION STATE')
+    },
+    'mailing-address': {
+      on: {
+        NEXT: {
+          target: 'shortcut',
+          actions: log(
+            (ctx, event) => 'mailAddressing'
+          )
+        }
+      },
+      meta: {
+        path: '/basic-info/mailing-address',
+      },
+      onEntry: () => console.log('entered mailAddress')
+    },
+    shortcut: {
+      on: {
+        EXIT: {
+          target: '#submit',
+          actions: log(
+            (ctx, event) => 'offramping'
+          )
+        },
+        NEXT: {
+          target: '#identity',
+          actions: log(
+            (ctx, event) => 'to identity'
+          )
+        }
+      },
+      meta: {
+        path: '/basic-info/shortcut'
+      },
+      onEntry: () => console.log('entered offramp')
+    }
+  }
+};
+
+const identityState = {
+  id: 'identity',
+  initial: 'personal-info',
+  states: {
+    'personal-info': {
+      on: {
+        NEXT: '#household'
+      },
+      meta: {
+        path: '/identity/personal-info',
+      },
+    },
+  },
+};
+
+const formStateConfig = {
+  id: 'form',
+  initial: 'basic-info',
+  states: {
+    'basic-info': basicInfoState,
+    identity: identityState,
+    household: {
+
+    },
+    adverse: {
+
+    },
+    resources: {
+
+    },
+    review: {
+
+    },
+    submit: {
+      onEntry: [() => console.log('entered submit')]   
+    }
+  }
+};
+
+export default formStateConfig;

--- a/src/models/basic-info.js
+++ b/src/models/basic-info.js
@@ -11,5 +11,5 @@ export default () => ({
   residenceAddress: address(),
   mailingAddress: address(),
   county: '',
-  currentMailingAddress: true
+  currentMailingAddress: false
 });

--- a/src/pages/form/dsnap-form.js
+++ b/src/pages/form/dsnap-form.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import FSMRouter, { MachineConsumer } from 'components/fsm';
 import Wizard from 'components/wizard';
 import basicInfo from 'models/basic-info';
+import fsmConfig from 'fsm-config';
 
 class DSNAPForm extends React.Component {
   state = {
@@ -12,14 +14,22 @@ class DSNAPForm extends React.Component {
   }
 
   render() {
-    const { config } = this.props;
-
+    const { config } = this.props
     return (
-      <Wizard
-        initialValues={this.state}
-        onDone={this.handleFormComplete}
-        config={config}
-      />
+      <FSMRouter config={fsmConfig}>
+        <MachineConsumer>
+          {(handleNext) => {
+            return (
+              <Wizard
+                initialValues={this.state}
+                onNext={handleNext}
+                onDone={this.handleFormComplete}
+                config={config}
+              />
+            );
+          }}
+        </MachineConsumer>
+      </FSMRouter>
     );
   }
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import AppContainer from './components/app-container';
-import NoMatch from './components/no-match';
+import Route404 from 'components/404-route';
+import NoMatch from 'components/no-match';
 import FormComplete from 'pages/form-complete';
 import PreregistrationPage from 'pages/preregistration';
 import PreparePage from 'pages/prepare';
@@ -27,8 +28,9 @@ const Routes = () => (
           render={() => <DSNAPForm config={wizardRouteConfig} /> }
         />
         <Route path="/form/complete" component={FormComplete} />
-        <Route component={NoMatch} />  
+        <Route component={Route404} />
       </Switch>
+      <Route path="/not-found" component={NoMatch} />
     </AppContainer>
   </Switch>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9532,6 +9532,10 @@ xregexp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
 
+xstate@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.3.1.tgz#54554b2116470fe630ca3b7e92ff1ce74b508ff9"
+
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"


### PR DESCRIPTION
TODOS, in no particular order:

- [ x ] dynamically generate list of available 'goto' routes from machine config
- [ x ] clean up  fsm code

**bonus round**
* consider a better set of interactions between the current wizard and the FSM component?
* probably want a node config factory for the FSM config...something to automatically handle assigning the correct props in the correct places e.g. putting the `meta` attribute in the correct place