### PR TITLE
Handle transition and persistence between sections

### DIFF
--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -85,11 +85,12 @@ class Section extends React.Component {
   handleSubmit = (values, actions) => {
     const isLastStep = this.isLastStep();
 
+    this.next(values);
+
     if (isLastStep) {
       this.props.handleSubmit(values);
     } else {
       actions.setSubmitting(false);
-      this.next(values);
     }
   }
 
@@ -254,6 +255,7 @@ class Wizard extends React.Component {
   state = {
     step: 0,
   }
+
   formStarted = false;
 
   next = (values) =>

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -148,16 +148,8 @@ const basicInfoState = {
       on: {
         EXIT: {
           target: '#submit',
-          actions: log(
-            (ctx, event) => 'offramping'
-          )
         },
-        NEXT: {
-          target: '#identity',
-          actions: log(
-            (ctx, event) => 'to identity'
-          )
-        }
+        ...formNextHandler('#identity'),
       },
       meta: {
         path: '/basic-info/shortcut'
@@ -176,7 +168,7 @@ const basicInfoState = {
 const identityState = {
   id: 'identity',
   initial: 'personal-info',
-  onEnter: [
+  onEntry: [
     assign({ currentSection: 'identity' })
   ],
   onExit: [
@@ -184,14 +176,14 @@ const identityState = {
   ],
   states: {
     'personal-info': {
-      onEnter: [
+      onEntry: [
         assign({ currentStep: 'personalInfo' })
       ],
       onExit: [
         assign({ previousStep: 'personalInfo' })
       ],
       on: {
-        NEXT: '#household'
+        ...formNextHandler('#household')
       },
       meta: {
         path: '/identity/personal-info',

--- a/src/route-config.js
+++ b/src/route-config.js
@@ -26,6 +26,7 @@ export default [{
 }, {
   path: '/form/identity',
   component: Sections.IdentitySection,
+  name: 'identity',
   routes: [
     {
       path: '/form/identity/personal-info',


### PR DESCRIPTION
Users can properly transition between the `basic-info` and `identity` sections