### PR TITLE
Route user to correct form section/step

### DIFF
--- a/src/components/fsm.js
+++ b/src/components/fsm.js
@@ -65,8 +65,13 @@ class FSMRouter extends React.Component {
     
     this.service.onTransition(this.handleXStateTransition);
     this.service.start();
-    
-    this.handleHistoryTransition(this.props.location);
+
+    const { context } = this.machineState;
+
+    this.handleHistoryTransition({
+      pathname: `/form/${context.currentSection}/${context.currentStep}`
+    });
+
     this.historySubscriber = props.history.listen(this.historyHandler);
   }
 


### PR DESCRIPTION
* Use persisted information in local storage, or to
'basic-info/applicant-name'

* Hardcodes initial steps in `fsm-configs`, but these could esily be
configurable

* Introduces `idle` state for each machine to initialize into, lets the
`FSMRouterq component handle sending the correct transition message to
the state machine