### PR TITLE
Update basic-info model to use `person` model

### DIFF
--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -19,7 +19,7 @@ const propTypes = {
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
-  ]).isRequired,
+  ])
 };
 
 class Input extends React.Component {
@@ -104,7 +104,6 @@ class Input extends React.Component {
           name={name}
           onChange={this.props.onChange}
           onBlur={this.props.onBlur}
-          value={this.props.value}
         />
         <ErrorMessage name={name}>
           { message => <InputError message={message} /> }

--- a/src/components/radio-checkbox/index.js
+++ b/src/components/radio-checkbox/index.js
@@ -50,7 +50,7 @@ class RadioCheckbox extends React.Component {
   
   formGroupClassName() {
     return classnames({
-      'border radius-md border-base-light display-inline-block margin-right-2': this.isRadio()
+      'border radius-md border-base-light display-inline-block margin-right-2': this.isRadio(),
     });
   }
 

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -35,12 +35,13 @@ class Section extends React.Component {
 
   next = (values) => {
     const { current } = this.state;
+    const formValues = this.props.formik.values;
       // call the onNext handler for the step, if it exists
     const nextValues = (
       current &&
       current.props.onNext &&
-      current.props.onNext(values)
-    ) || values;
+      current.props.onNext(formValues)
+    ) || formValues;
 
     this.formStarted = true;
     this.props.onNext({ data: nextValues });
@@ -101,11 +102,6 @@ class Section extends React.Component {
     }
   }
 
-  handleChange = formikHandler => nextValues => {
-    formikHandler(nextValues);
-    this.props.handleChange(nextValues);
-  }
-
   hasErrors(errors = {}) {
     return Object.keys(errors).length >= 1;
   }
@@ -154,7 +150,7 @@ class Section extends React.Component {
                             route={route}
                             extraProps={{
                               sectionName: this.props.name,
-                              handleChange: this.handleChange(formikProps.handleChange),
+                              handleChange: this.props.handleChange,
                               registerStep: this.registerStepComponent,
                               handleNext: this.props.handleNext
                             }}

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -102,6 +102,11 @@ class Section extends React.Component {
     }
   }
 
+  handleChange = formikHandler => nextValues => {
+    formikHandler(nextValues);
+    this.props.handleChange(nextValues);
+  }
+
   hasErrors(errors = {}) {
     return Object.keys(errors).length >= 1;
   }
@@ -150,7 +155,7 @@ class Section extends React.Component {
                             route={route}
                             extraProps={{
                               sectionName: this.props.name,
-                              handleChange: this.props.handleChange,
+                              handleChange: this.handleChange(formikProps.handleChange),
                               registerStep: this.registerStepComponent,
                               handleNext: this.props.handleNext
                             }}
@@ -173,7 +178,6 @@ class Section extends React.Component {
                 >
                   { this.props.t('general.quit') }
                 </Button>
-                <Debug name={`Section ${this.props.name} state`}/>
               </Form>
             );
           }}

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -48,10 +48,8 @@ const formNextHandler = target => ({
       // open question: why doesnt xstate persist the context when an
       // assign call is made within another function?
       assign((ctx, event) => {
-        const section = currentSectionSelector(ctx);
-
         return {
-          [section]: (event[section] || modelState[section])
+          ...event
         };
       })
     ]

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -377,7 +377,6 @@ const formStateConfig = {
 
 const extraActions = {
   persist: (context, {type, ...data}) => {
-    debugger
     const nextState = (() => {
       // we are transitioning through a null state, which doesn't provide
       // data to the state machine. so, just write the current context to local storage
@@ -385,22 +384,20 @@ const extraActions = {
         return context;
       }
 
-      const section = currentSectionSelector(context);
-
       const overwrites = Object.entries(data).reduce((memo, [name, nextData]) => {
+        const existingContextSlice = context[name];
+        const formattedContextSlice = typeof existingContextSlice === 'string' ?
+          nextData : { ...context[name], ...nextData }; 
+
         return {
           ...memo,
-          [name]: {
-            ...context[name],
-            ...nextData
-          }
+          [name]: formattedContextSlice,
         }
       }, {});
 
       return {
         ...context,
         ...overwrites
-        //[section]: (data[section] || modelState[section]),
       };
     })();
 

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -205,7 +205,6 @@ const householdChart = {
       ],
       onExit: [
         assign({ previousStep: 'how-many' }),
-        (context) => actions.send({ type: 'NEXT', ...context })
       ],
     },
     'member-info-branch': {
@@ -214,13 +213,13 @@ const householdChart = {
           {
             target: 'member-names',
             cond: (context) => {
-              return Number(getHouseholdCount(context.household));
+              return getHouseholdCount(context.household) > 1;
             }
           },
           {
-            target: '#impact',
+            target: 'food-assistance',
             cond: (context) => {
-              return !Number(getHouseholdCount(context.household));
+              return getHouseholdCount(context.household) === 1;
             }
           },
         ],
@@ -316,7 +315,6 @@ const impactChart = {
   states: {
     'adverse-effects': {
       onEntry: [
-        () => console.log('entered adverse'),
         assign({ currentStep: 'adverse-effects' }),
       ],
       onExit: assign({ previousStep: 'adverse-effects' }),

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -319,7 +319,7 @@ const impactChart = {
       ],
       onExit: assign({ previousStep: 'adverse-effects' }),
       meta: {
-        path: '/impact'
+        path: '/impact/adverse-effects'
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -49,7 +49,7 @@
     "action": "Start registering"
   },
   "basicInfo": {
-    "applicantName": {
+    "name": {
       "header": "Let’s start with the basics.",
       "firstName": {
         "label": "What is your legal first name?",

--- a/src/models/basic-info.js
+++ b/src/models/basic-info.js
@@ -1,9 +1,7 @@
 import address from './address';
 
-export const getCustomerFirstName = info => info.applicantName.firstName;
-
-export default () => ({ 
-  applicantName: {
+export default () => ({
+  name: {
     firstName: '',
     middleName: '',
     lastName: '',

--- a/src/models/basic-info.js
+++ b/src/models/basic-info.js
@@ -1,11 +1,7 @@
 import address from './address';
 
 export default () => ({
-  name: {
-    firstName: '',
-    middleName: '',
-    lastName: '',
-  },
+  personId: 0,
   phone: '',
   email: '',
   residenceAddress: address(),
@@ -13,3 +9,5 @@ export default () => ({
   county: '',
   currentMailingAddress: false
 });
+
+export const hasMailingAddress = info => info.currentMailingAddress !== 'true';

--- a/src/models/household.js
+++ b/src/models/household.js
@@ -1,9 +1,9 @@
 import person from './person';
 
 export default () => ({
-  numMembers: '',
+  numMembers: 1,
   currentMemberIndex: 0,
-  members: [],
+  members: [ person() ],
 });
 
 export const getHouseholdCount = (household) => household.numMembers;
@@ -14,9 +14,11 @@ export const getCurrentMemberIndex = ({ currentMemberIndex }) =>
 export const hasAdditionalMembers = household =>
   household.currentMemberIndex < household.members.length - 1;
 
-export const addPeopleToHousehold = (household, count) => ({
+export const addPeopleToHousehold = (household, count, data = {}) => ({
   ...household,
-  members: Array.apply(null, { length: count }).map(person),
+  members: Array.apply(null, {
+    length: count
+  }).map(() => ({ ...person(), ...data })),
 });
 
 export const updateCurrentMemberIndex = (household, index) => ({

--- a/src/models/household.js
+++ b/src/models/household.js
@@ -6,8 +6,10 @@ export default () => ({
   members: [ person() ],
 });
 
-export const getHouseholdCount = (household) => household.numMembers;
-export const getMembers = (household) => household.members;
+
+export const getHouseholdCount = household => household.numMembers;
+export const getMembers = household => household.members;
+export const getApplicant = household => getMembers(household)[0];
 export const getCurrentMemberIndex = ({ currentMemberIndex }) =>
   typeof currentMemberIndex !== 'number' ? 0 : currentMemberIndex;
 

--- a/src/models/household.js
+++ b/src/models/household.js
@@ -1,29 +1,38 @@
 import person from './person';
 
 export default () => ({
-  numMembers: 1,
+  // refers to number of additional members of a given household,
+  // beyond the primary applicant
+  numMembers: 0,
   currentMemberIndex: 0,
   members: [ person() ],
 });
 
 
-export const getHouseholdCount = household => household.numMembers;
+export const getHouseholdCount = household => household.members.length;
 export const getMembers = household => household.members;
 export const getApplicant = household => getMembers(household)[0];
 export const getCurrentMemberIndex = ({ currentMemberIndex }) =>
   typeof currentMemberIndex !== 'number' ? 0 : currentMemberIndex;
 
 export const hasAdditionalMembers = household =>
-  household.currentMemberIndex < household.members.length - 1;
+  household.currentMemberIndex < getHouseholdCount(household) - 1;
 
-export const addPeopleToHousehold = (household, count, data = {}) => ({
-  ...household,
-  members: Array.apply(null, {
-    length: count
-  }).map(() => ({ ...person(), ...data })),
-});
+export const addPeopleToHousehold = (household, count) => {
+  const { members, ...rest } = household;
+
+  return {
+    ...rest,
+    members: [
+      ...members,
+      ...Array.apply(null, {
+        length: count
+      }).map(person)
+    ]
+  };
+};
 
 export const updateCurrentMemberIndex = (household, index) => ({
   ...household,
-  currentMemberIndex: index >= household.members.length ? household.members.length - 1 : index
+  currentMemberIndex: index >= getHouseholdCount(household) ? getHouseholdCount(household) - 1 : index
 });

--- a/src/models/identity.js
+++ b/src/models/identity.js
@@ -1,13 +1,5 @@
 export default () => ({
   personalInfo: {
-    dob: {
-      month: '',
-      day: '',
-      year: '',
-    },
-    sex: '',
-    ssn: '',
-    race: '',
     stateId: '',
   },
 });

--- a/src/models/person.js
+++ b/src/models/person.js
@@ -13,6 +13,8 @@ export default () => {
     sex: '',
     ssn: '',
     race: '',
-    hasFoodAssistance: "false"
+    hasFoodAssistance: false,
   };
 };
+
+export const getFirstName = person => person.name.firstName;

--- a/src/pages/form/steps/basic-info/applicant-name.js
+++ b/src/pages/form/steps/basic-info/applicant-name.js
@@ -7,7 +7,7 @@ import withLocale from 'components/with-locale';
 import { nameValidator } from 'validators/basic-info';
 
 class ApplicantName extends React.Component {
-  static modelName = 'applicantName'
+  static modelName = 'name'
 
   static propTypes = {
     handleChange: PropTypes.func,

--- a/src/pages/form/steps/basic-info/applicant-name.js
+++ b/src/pages/form/steps/basic-info/applicant-name.js
@@ -27,20 +27,20 @@ class ApplicantName extends React.Component {
         validate={nameValidator}
       >
         <FormikField
-          name={`${sectionName}.${modelName}.firstName`}
+          name={buildNestedKey('household', 'members', '0', 'name', 'firstName')}
           onChange={handleChange}
-          explanation={t(`${buildNestedKey(sectionName, modelName, 'firstName', 'explanation')}`)}
-          labelText={t(`${buildNestedKey(sectionName, modelName, 'firstName', 'label')}`)}
+          explanation={t(buildNestedKey(sectionName, modelName, 'firstName', 'explanation'))}
+          labelText={t(buildNestedKey(sectionName, modelName, 'firstName', 'label'))}
         />
         <FormikField
-          name={`${sectionName}.${modelName}.middleName`}
+          name={buildNestedKey('household', 'members', '0', 'name', 'middleName')}
           onChange={handleChange}
-          labelText={t(`${buildNestedKey(sectionName, modelName, 'middleName', 'label')}`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'middleName', 'label'))}
         />
         <FormikField
-          name={`${sectionName}.${modelName}.lastName`}
+          name={buildNestedKey('household', 'members', '0', 'name', 'lastName')}
           onChange={handleChange}
-          labelText={t(`${buildNestedKey(sectionName, modelName, 'lastName', 'label')}`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'lastName', 'label'))}
         />
       </Wizard.Step>
     );

--- a/src/pages/form/steps/basic-info/offramp.js
+++ b/src/pages/form/steps/basic-info/offramp.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withLocale from 'components/with-locale';
 import UI from 'components/ui';
+import { getFirstName } from 'models/person';
 import { MachineState } from 'components/fsm';
 
 class BasicInfoOffRamp extends React.Component {
@@ -14,20 +15,19 @@ class BasicInfoOffRamp extends React.Component {
 
     return (
       <MachineState>
-        {(state) => (
+        {({ basicInfo }) => (
           <section>
             <UI.Header type="h1" border>
-              { /* TODO: need selectors for this data!! */}
-              { t(`basicInfo.offramp.header`, { customerName: state.basicInfo.applicantName.firstName }) }
+              { t('basicInfo.offramp.header', { customerName: getFirstName(basicInfo) }) }
             </UI.Header>
             <div className="grid-col desktop:grid-col-8 margin-y-4 desktop:font-ui-lg">
               <p>
-                { t(`basicInfo.offramp.copy`) }
+                { t('basicInfo.offramp.copy') }
               </p>
             </div>
             <div className="grid-col desktop:grid-col-8 padding-2 desktop:padding-4 margin-y-4 border radius-md desktop:font-ui-lg border-mint text-mint">
               <p>
-                { t(`basicInfo.offramp.alerts.success`) }
+                { t('basicInfo.offramp.alerts.success') }
               </p>
             </div>
           </section>

--- a/src/pages/form/steps/basic-info/offramp.js
+++ b/src/pages/form/steps/basic-info/offramp.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withLocale from 'components/with-locale';
 import UI from 'components/ui';
+import { getApplicant } from 'models/household';
 import { getFirstName } from 'models/person';
 import { MachineState } from 'components/fsm';
 
@@ -15,10 +16,10 @@ class BasicInfoOffRamp extends React.Component {
 
     return (
       <MachineState>
-        {({ basicInfo }) => (
+        {({ basicInfo, household }) => (
           <section>
             <UI.Header type="h1" border>
-              { t('basicInfo.offramp.header', { customerName: getFirstName(basicInfo) }) }
+              { t('basicInfo.offramp.header', { customerName: getFirstName(getApplicant(household)) }) }
             </UI.Header>
             <div className="grid-col desktop:grid-col-8 margin-y-4 desktop:font-ui-lg">
               <p>

--- a/src/pages/form/steps/household/how-many.js
+++ b/src/pages/form/steps/household/how-many.js
@@ -22,8 +22,8 @@ const HowMany = ({ handleChange, sectionName, t, registerStep }) =>
         onNext={addToHousehold(household)}
       >
         <FormikField
-          labelText={t(`${buildNestedKey(sectionName, modelName, 'label')}`)}
-          explanation={t(`${buildNestedKey(sectionName, modelName, 'explanation')}`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'label'))}
+          explanation={t(buildNestedKey(sectionName, modelName, 'explanation'))}
           onChange={handleChange}
           type="number"
           name={`${sectionName}.numMembers`}

--- a/src/pages/form/steps/household/member-names.js
+++ b/src/pages/form/steps/household/member-names.js
@@ -5,7 +5,7 @@ import Wizard from 'components/wizard';
 import FormikField from 'components/formik-field';
 import { buildNestedKey } from 'utils';
 import { getFirstName } from 'models/person';
-import { getMembers } from 'models/household';
+import { getMembers, getApplicant } from 'models/household';
 import UI from 'components/ui';
 
 const modelName = 'memberNames';
@@ -13,7 +13,7 @@ const modelName = 'memberNames';
 const MemberNames = ({ handleChange, sectionName, t, registerStep }) => (
   <Wizard.Context>
     {({ basicInfo, household }) => {
-      const customerName = getFirstName(basicInfo);
+      const customerName = getFirstName(getApplicant(household));
 
       return (
         <Wizard.Step

--- a/src/pages/form/steps/household/member-names.js
+++ b/src/pages/form/steps/household/member-names.js
@@ -4,7 +4,7 @@ import withLocale from 'components/with-locale';
 import Wizard from 'components/wizard';
 import FormikField from 'components/formik-field';
 import { buildNestedKey } from 'utils';
-import { getCustomerFirstName } from 'models/basic-info';
+import { getFirstName } from 'models/person';
 import { getMembers } from 'models/household';
 import UI from 'components/ui';
 
@@ -13,7 +13,7 @@ const modelName = 'memberNames';
 const MemberNames = ({ handleChange, sectionName, t, registerStep }) => (
   <Wizard.Context>
     {({ basicInfo, household }) => {
-      const customerName = getCustomerFirstName(basicInfo);
+      const customerName = getFirstName(basicInfo);
 
       return (
         <Wizard.Step

--- a/src/pages/form/steps/identity/index.js
+++ b/src/pages/form/steps/identity/index.js
@@ -26,25 +26,25 @@ class PersonalInfo extends React.Component {
     
     return (
       <Wizard.Step
-        header={t(`${buildNestedKey(sectionName, modelName)}.header`)}
+        header={t(buildNestedKey(sectionName, modelName, 'header'))}
         registerStep={this.props.registerStep}
         modelName={modelName}
       >
         <FormikFieldGroup
           inline
-          labelText={t(`${buildNestedKey(sectionName, modelName)}.dob.label`)}
-          explanation={t(`${buildNestedKey(sectionName, modelName)}.dob.explanation`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'dob', 'label'))}
+          explanation={t(buildNestedKey(sectionName, modelName, 'dob', 'explanation'))}
           fields={[{
-            name: `${sectionName}.${modelName}.dob.month`,
+            name: 'household.members.0.dob.month',
             onChange: handleChange,
-            labelText: t(`${buildNestedKey(sectionName, modelName)}.dob.month`),
+            labelText: t(buildNestedKey(sectionName, modelName, 'dob', 'month')),
           }, {
-            name: `${sectionName}.${modelName}.dob.day`,
-            labelText: t(`${buildNestedKey(sectionName, modelName)}.dob.day`),
+            name: 'household.members.0.dob.day',
+            labelText: t(buildNestedKey(sectionName, modelName, 'dob', 'day')),
             onChange: handleChange
           }, {
-            name: `${sectionName}.${modelName}.dob.year`,
-            labelText: t(`${buildNestedKey(sectionName, modelName)}.dob.year`),
+            name: 'household.members.0.dob.year',
+            labelText: t(buildNestedKey(sectionName, modelName, 'dob', 'year')),
             onChange: handleChange,
             className: 'desktop:grid-col-9'
           }]}
@@ -52,14 +52,14 @@ class PersonalInfo extends React.Component {
         <FormikField
           name={`${sectionName}.${modelName}.stateId`}
           onChange={handleChange}
-          labelText={t(`${buildNestedKey(sectionName, modelName)}.stateId.label`)}
-          explanation={t(`${buildNestedKey(sectionName, modelName)}.stateId.explanation`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'stateId', 'label'))}
+          explanation={t(buildNestedKey(sectionName, modelName, 'stateId', 'explanation'))}
         />
         <FormikField
-          name={`${sectionName}.${modelName}.ssn`}
+          name="household.members.0.ssn"
           onChange={handleChange}
-          labelText={t(`${buildNestedKey(sectionName, modelName)}.ssn.label`)}
-          explanation={t(`${buildNestedKey(sectionName, modelName)}.ssn.explanation`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'ssn', 'label'))}
+          explanation={t(buildNestedKey(sectionName, modelName, 'ssn', 'explanation'))}
         />
         <div className="margin-y-4">
           <Collapsible
@@ -84,15 +84,15 @@ class PersonalInfo extends React.Component {
             label: t(buildNestedKey(sectionName, modelName, 'sex', 'options', 'female')),
             value: "female"
           }]}
-          name={`${sectionName}.${modelName}.sex`}
+          name="household.members.0.sex"
           onChange={handleChange}
-          labelText={t(`${buildNestedKey(sectionName, modelName, 'sex', 'label')}`)}
-          explanation={t(`${buildNestedKey(sectionName, modelName, 'sex', 'explanation')}`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'sex', 'label'))}
+          explanation={t(buildNestedKey(sectionName, modelName, 'sex', 'explanation'))}
         />
         <FormikField
-          name={`${sectionName}.${modelName}.race`}
+          name="household.members.0.race"
           onChange={handleChange}
-          labelText={t(`${buildNestedKey(sectionName, modelName)}.race.label`)}
+          labelText={t(buildNestedKey(sectionName, modelName, 'race', 'label'))}
         />
         <SecurityAlert />
       </Wizard.Step>

--- a/src/validators/basic-info/name.js
+++ b/src/validators/basic-info/name.js
@@ -6,9 +6,9 @@ export default ({ firstName, lastName }) => {
   let errors = {};
 
   if (!firstName) {
-    errors = setIn(errors, 'basicInfo.applicantName.firstName', i18n.t('errors.required'));
+    errors = setIn(errors, 'basicInfo.name.firstName', i18n.t('errors.required'));
   } else if (!lastName) {
-    errors = setIn(errors, 'basicInfo.applicantName.lastName', i18n.t('errors.required'));
+    errors = setIn(errors, 'basicInfo.name.lastName', i18n.t('errors.required'));
   }
 
   return errors;


### PR DESCRIPTION
`BasicInfo` data model now has a pointer to an instance of a `person` model — this means that the primary applicant can be logically handled the same as other household members when reporting and verifying current food assistance  benefits, job income and income loss