### PR TITLE
Job entry form clears on next

### DIFF
--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -104,6 +104,7 @@ class Input extends React.Component {
           name={name}
           onChange={this.props.onChange}
           onBlur={this.props.onBlur}
+          value={this.props.value}
         />
         <ErrorMessage name={name}>
           { message => <InputError message={message} /> }

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -308,7 +308,7 @@ class Wizard extends React.Component {
           onSubmit={this.handleSubmit}
           validate={this.validate}
           render={({ values, handleSubmit, handleChange, errors }) => {
-            let providedValues = this.formStarted ? values : this.props.initialValues;
+            let providedValues = this.formStarted ? values : this.props.initialValues;          
 
             return (
               <WizardContext.Provider value={values}>

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -111,27 +111,13 @@ class Section extends React.Component {
     return Object.keys(errors).length >= 1;
   }
 
-  selectState(stateKeys) {
-    const { values } = this.props;
-
-    return stateKeys.reduce((memo, key) => {
-      const slice = values[key] || {};
-
-      return { ...memo, [key]: { ...slice } };
-    }, {});
-  }
-
   render() {
-    const { name, modelName } = this.props;
-    // TODO: need to separate out the concept of name being used for translations
-    // and data model keys. Not sure why I coupled them earlier!
-    const stateName = modelName ? modelName : Array.isArray(name) ? name : [name];
     return (
       <section>
         <h2>{this.props.header}</h2>
         <Formik
           enableReinitialize
-          initialValues={this.selectState(stateName)}
+          initialValues={this.props.values}
           onSubmit={this.handleSubmit}
           validateOnBlur={this.props.validateOnBlur}
           validateOnChange={this.props.validateOnChange}

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -13,7 +13,6 @@ const STATE_KEY = 'dsnap-registration';
 const initialState = () => {
   const machineState = {
     ...modelState,
-    currentModel: null,
     currentSection: 'basic-info',
     currentStep: 'applicant-name',
     previousStep: null,
@@ -27,7 +26,7 @@ const initialState = () => {
      * but is not exposed to the user. Therefore, it is not included in the total
      * number of steps
      */
-    totalSteps: 5,
+    totalSteps: 6,
   };
   let state;
 
@@ -67,7 +66,6 @@ const basicInfoChart = {
   onEntry: [
     assign({
       currentSection: 'basic-info',
-      currentModel: 'basicInfo',
       step: 1,
     })
   ],
@@ -158,7 +156,6 @@ const identityChart = {
   onEntry: [
     assign({
       currentSection: 'identity',
-      currentModel: 'identity',
       step: 2,
     })
   ],
@@ -189,7 +186,6 @@ const householdChart = {
   onEntry: [
     assign({
       currentSection: 'household',
-      currentModel: 'household',
       step: 3,
     })
   ],
@@ -309,7 +305,6 @@ const impactChart = {
   onEntry: [
     assign({
       currentSection: 'impact',
-      currentModel: 'impact',
       step: 4,
     })
   ],
@@ -343,7 +338,6 @@ const resourcesChart = {
   onEntry: [
     assign({
       currentSection: 'resources',
-      currentModel: 'resources',
       step: 5,
     })
   ],
@@ -388,7 +382,7 @@ const resourcesChart = {
       on: {
         '': [
           {
-            target: '#form.review',
+            target: '#review',
             cond: (context) => {
               return !context.resources.membersWithIncome.length;
             }
@@ -480,6 +474,31 @@ const resourcesChart = {
   }
 };
 
+const reviewChart = {
+  id: 'review',
+  initial: 'default',
+  strict: true,
+  onEntry: assign({
+    currentSection: 'review',
+    currentStep: 'review',
+    step: 6
+  }),
+  onExit: assign({
+    previousSection: 'review',
+    previousStep: 'review'
+  }),
+  states: {
+    default: {
+      meta: {
+        path: '/review'
+      },
+      on: {
+        ...formNextHandler('#submit')
+      }
+    }
+  }
+};
+
 
 const formStateConfig = {
   id: 'form',
@@ -496,14 +515,11 @@ const formStateConfig = {
     household: householdChart,
     impact: impactChart,
     resources: resourcesChart,
-    review: {
-      onEntry: [
-        () => console.log('review step')
-      ]
-    },
+    review: reviewChart,
     submit: {
       onEntry: [() => console.log('entered submit')]   
     },
+    finish: {},
     quit: {
       invoke: {
         id: 'clearSessionState',

--- a/src/pages/form/sections/index.js
+++ b/src/pages/form/sections/index.js
@@ -3,6 +3,7 @@ import IdentitySection from './identity';
 import HouseholdSection from './household';
 import ImpactSection from './impact';
 import ResourcesSection from './resources';
+import ReviewSection from './review';
 
 export default {
   BasicInfoSection,
@@ -10,4 +11,5 @@ export default {
   HouseholdSection,
   ImpactSection,
   ResourcesSection,
+  ReviewSection
 };

--- a/src/pages/form/steps/resources/jobs.js
+++ b/src/pages/form/steps/resources/jobs.js
@@ -7,6 +7,7 @@ import { buildNestedKey } from 'utils';
 import { getMembers, updateMemberAtIndex } from 'models/household';
 import { getFirstName, hasOtherJobs } from 'models/person';
 import { addJob } from 'models/assets-and-income';
+import job from 'models/job';
 
 const modelName = 'jobs';
 
@@ -30,7 +31,7 @@ const handleNext = (values) => () => {
     household: {
       ...nextHousehold
     },
-    newJob: {},
+    newJob: job(),
   };
 
   if (!hasOtherJobs(member)) {
@@ -50,7 +51,6 @@ const handleNext = (values) => () => {
 class Jobs extends React.Component {
   render() {
     const { handleChange, sectionName, registerStep, t } = this.props;
-
     return (
       <Wizard.Context>
         {(values) => {
@@ -60,7 +60,7 @@ class Jobs extends React.Component {
           const index = resources.membersWithIncome[0];
           const member = members[index];
           const firstName = getFirstName(member);
-                
+
           return (
             <Wizard.Step
               header={t(buildNestedKey(sectionName, modelName, 'header'), { firstName })}

--- a/src/pages/form/steps/resources/jobs.js
+++ b/src/pages/form/steps/resources/jobs.js
@@ -17,11 +17,7 @@ const handleNext = (values) => () => {
   const member = members[index];
   // TODO: make jobs / other jobs not nested under member so
   // all these relationships dont have to be resolved here
-  const nextJobs = addJob(member.assetsAndIncome.jobs, newJob);
-  const nextIncome = {
-    ...member.assetsAndIncome,
-    jobs: nextJobs
-  };
+  const nextIncome = addJob(member.assetsAndIncome, newJob);
 
   const nextMember = {
     ...member,

--- a/src/route-config.js
+++ b/src/route-config.js
@@ -87,4 +87,9 @@ export default [{
       component: Steps.Resources.Jobs
     }
   ]
+}, {
+  path: '/form/review',
+  component: Sections.ReviewSection,
+  name: 'review',
+  routes: []
 }];


### PR DESCRIPTION
Previously, when a user entered job data and indicated they had additional jobs, the `next` button behavior would not clear the old job from the form. This PR corrects that behavior.