### PR TITLE
Clear job entry form on submit

### DIFF
--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -104,6 +104,7 @@ class Input extends React.Component {
           name={name}
           onChange={this.props.onChange}
           onBlur={this.props.onBlur}
+          value={this.props.value}
         />
         <ErrorMessage name={name}>
           { message => <InputError message={message} /> }

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -322,7 +322,7 @@ class Wizard extends React.Component {
           onSubmit={this.handleSubmit}
           validate={this.validate}
           render={({ values, handleSubmit, handleChange, errors }) => {
-            let providedValues = this.formStarted ? values : this.props.initialValues;
+            let providedValues = this.formStarted ? values : this.props.initialValues;          
 
             return (
               <WizardContext.Provider value={values}>

--- a/src/pages/form/steps/resources/jobs.js
+++ b/src/pages/form/steps/resources/jobs.js
@@ -7,6 +7,7 @@ import { buildNestedKey } from 'utils';
 import { getMembers, updateMemberAtIndex } from 'models/household';
 import { getFirstName, hasOtherJobs } from 'models/person';
 import { addJob } from 'models/assets-and-income';
+import job from 'models/job';
 
 const modelName = 'jobs';
 
@@ -34,7 +35,7 @@ const handleNext = (values) => () => {
     household: {
       ...nextHousehold
     },
-    newJob: {},
+    newJob: job(),
   };
 
   if (!hasOtherJobs(member)) {
@@ -54,7 +55,6 @@ const handleNext = (values) => () => {
 class Jobs extends React.Component {
   render() {
     const { handleChange, sectionName, registerStep, t } = this.props;
-
     return (
       <Wizard.Context>
         {(values) => {
@@ -64,7 +64,7 @@ class Jobs extends React.Component {
           const index = resources.membersWithIncome[0];
           const member = members[index];
           const firstName = getFirstName(member);
-                
+
           return (
             <Wizard.Step
               header={t(buildNestedKey(sectionName, modelName, 'header'), { firstName })}


### PR DESCRIPTION
Previously, when a user entered job data and indicated they had additional jobs, the `next` button behavior would not clear the old job from the form. This PR corrects that behavior.