### PR TITLE
Reinitialize disaster model on server error

### DIFF
--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -125,7 +125,9 @@ class Section extends React.Component {
           validateOnChange={this.props.validateOnChange}
           validate={this.validate}
           render={(formikProps) => {
-            const disable = this.hasErrors(formikProps.errors) || formikProps.isSubmitting; 
+            const disable = this.hasErrors(formikProps.errors) ||
+              formikProps.isSubmitting ||
+              this.props.values.errors.server;
 
             return (
               <WizardContext.Provider value={formikProps.values}>

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -544,15 +544,18 @@ const preRegistrationChart = {
           src: () => getDisasters(),
           onError: {
             target: 'set-up',
-            actions: assign({
-              errors: () => ({
-                server: true
-              }),
-              meta: (context) => ({
-                ...context.meta,
-                loading: false
+            actions: [
+              assign({
+                errors: () => ({
+                  server: true
+                }),
+                meta: (context) => ({
+                  ...context.meta,
+                  loading: false
+                }),
+                disasters: disaster(),
               })
-            })
+            ]
           },
           onDone: {
             target: 'set-up',

--- a/src/pages/pre-registration/index.js
+++ b/src/pages/pre-registration/index.js
@@ -10,7 +10,7 @@ import ErrorAlert from 'components/error-alert';
 
 class PreRegistrationPage extends React.Component {
   renderError(maybeErrors) {
-    if (getError(maybeErrors)) {
+    if (getError(maybeErrors, 'server')) {
       return (
         <ErrorAlert
           text={this.props.t('preregistration.disaster.error.server')}


### PR DESCRIPTION
* Should fix bug where code attempts to enumerate over a non enumerable
* Disable 'next' button on server error
* Fix call to getErrors fn by supplying the error type to check for