### PR TITLE
Use disaster id as key to get selected disaster

### DIFF
--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -561,9 +561,16 @@ const preRegistrationChart = {
             target: 'set-up',
             actions: [
               assign({
-               disasters: (_, event) => ({
-                  data: event.data,
-                }),
+               disasters: (_, event) => {
+                 return {
+                   data: event.data.reduce((memo, d) => {
+                      return {
+                        ...memo,
+                        [d.id]: d
+                      }
+                    }, {})
+                  };
+               },
                 meta: (context) => ({
                   ...context.meta,
                   loading: false

--- a/src/models/disaster.js
+++ b/src/models/disaster.js
@@ -1,11 +1,11 @@
 export const getDisaster = (disasters, index) => disasters.data[index] || {};
-export const getDisasters = disasters => disasters.data;
+export const getDisasters = disasters => Object.values(disasters.data);
 export const getBeginDate = disaster => disaster.benefit_begin_date;
 export const getCounties = (disasters, index, periodIndex) => {
   const benefitsPeriod = getDisaster(disasters, index).application_periods;
   let defaultValue = []
 
-  if (!benefitsPeriod.length) {
+  if (!benefitsPeriod || !benefitsPeriod.length) {
     return defaultValue;
   }
 

--- a/src/pages/pre-registration/index.js
+++ b/src/pages/pre-registration/index.js
@@ -54,13 +54,13 @@ const Step = ({ registerStep, handleChange, t }) => (
           <React.Fragment>
           <FormikFieldGroup
             labelText={t('preregistration.disaster.label')}
-            fields={getDisasters(disasters).map((disaster, index) => ({
+            fields={getDisasters(disasters).map((disaster) => ({
               type: 'radio',
               name: `basicInfo.disasterIndex`,
               labelText: disaster.title,
               onChange: handleChange,
-              radioValue: String(index),
-              id: `basicInfo.disasterIndex.${index}`
+              radioValue: String(disaster.id),
+              id: `basicInfo.disasterIndex.${disaster.id}`
             }))}
           />
           { !basicInfo.disasterIndex ? null :


### PR DESCRIPTION
* Previously, the app used the index of the disaster in the app's data
cache to reference which disaster the user had selected. Now, the app
transforms the disaster info from the server from an array into an
object keyed to the disaster's index