### PR TITLE
Fix issues with persist method in fsm

### DIFF
--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -1,5 +1,5 @@
 import { actions, assign } from 'xstate';
-import { isAffirmative } from 'utils';
+import { isAffirmative, isPrimitive } from 'utils';
 import testData from './test-data';
 import modelState from 'models';
 import config from 'models/config';
@@ -746,7 +746,7 @@ const extraActions = {
         .filter(([name, _]) => ignoreKeys.indexOf(name) === -1)
         .reduce((memo, [name, nextData]) => {
           const existingContextSlice = context[name];
-          const formattedContextSlice = typeof existingContextSlice === 'string' ?
+          const formattedContextSlice = isPrimitive(existingContextSlice) ?
             nextData : { ...context[name], ...nextData };
 
           return {

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,3 +12,8 @@ export const isAffirmative = value =>
   (value === "true" || value === true || value.toLowerCase() === YES);
 
 export const phoneMaskRegExp = /[()-]/;
+
+export const isPrimitive = value =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean';


### PR DESCRIPTION
* The persist method was not properly handling primitive types other
than strings, leading to some data being improerly set to an empty
object