### PR TITLE
Adds eager prop to FormikField, fixes #202

### DIFF
--- a/src/components/formik-field/index.js
+++ b/src/components/formik-field/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ErrorMessage, FastField } from 'formik';
+import { ErrorMessage, FastField, Field } from 'formik';
 import Input from 'components/input';
 import MaskedInput from 'components/masked-input';
 import InputError from 'components/error';
@@ -12,7 +12,7 @@ const inputTypes = (type) => {
   switch(type) {
     case 'text': return Input;
     case 'select': return Dropdown;
-    case 'mask': return MaskedInput
+    case 'mask': return MaskedInput;
     case 'radio':
     case 'checkbox':
       return RadioCheckbox;
@@ -28,11 +28,13 @@ class FormikField extends React.Component {
   }
 
   render() {
-    const { name, onChange, type, ...rest } = this.props;
+    const { name, onChange, type, eager, ...rest } = this.props;
+    const BaseComponent = eager ? Field : FastField;
     const InputComponent = inputTypes(type);
 
+
     return (
-      <FastField
+      <BaseComponent
         name={name}
         render={({ field }) => {
           return (

--- a/src/components/review/household.js
+++ b/src/components/review/household.js
@@ -76,6 +76,7 @@ class HouseholdReview extends React.Component {
         data: member.ssn,
         component: {
           props: {
+            eager: true,
             type: 'mask',
             pattern: 'XXX-XX-XXXX',
             delimiter: '-',

--- a/src/components/wizard/index.js
+++ b/src/components/wizard/index.js
@@ -318,24 +318,8 @@ class Wizard extends React.Component {
           onSubmit={this.handleSubmit}
           validate={this.validate}
           render={({ values, handleSubmit, handleChange, setValues, errors }) => {
-            let providedValues = this.formStarted ? values : this.props.initialValues;          
-            /**
-             * TODO
-             * Because there are two nested formik instances, whenever we call an update function in
-             * the nested `formik`, we MUST also pass the corresponding update function down from the parent
-             * parent `formik`'s instance.
-             *
-             * We do this to keep the two form states in sync. This is super cumbersome and brittle, so we
-             * need to do one of two things:
-             *
-             * 1). figure out how to automatically call updates on the parent form regardless of nesting depth
-             * 2). remove the nesting entirely, and just have a single  top level form state
-             *  The con to 2). is that the app will lose the ability to have discrete `formik` instances
-             *  that control slices of the form state. This form is small enough that it probably doesnt matter,
-             *  but it might be an issue for future, larger forms. I's probably better to design the base `formik`
-             *  wrapper component in such a way that nesting _could_ be possible in the future with additional
-             *  custom classes?
-             * */
+            let providedValues = this.formStarted ? values : this.props.initialValues;
+
             return (
               <React.Fragment>
                 <WizardContext.Provider value={providedValues}>


### PR DESCRIPTION
* `eager: true` will use formik's `Field` component as the underlying
form component. This ensures the component will always be re-rendered
when new props are received, as opposed to `FastField` behavior, which
only rerenders the component when input values change