### PR TITLE
Set expenses to applicable and zero if no value

### DIFF
--- a/src/pages/form/steps/impact/index.js
+++ b/src/pages/form/steps/impact/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'formik';
 import withLocale from 'components/with-locale';
 import Wizard from 'components/wizard';
 import FormikField, { FormikFieldGroup } from 'components/formik-field';
@@ -6,78 +7,94 @@ import YesNoField from 'components/yes-no-field';
 import ComboField from 'components/combo-field';
 import { buildNestedKey } from 'utils';
 import { getDisaster } from 'models/disaster';
+import { getApplicant, updateMemberAtIndex } from 'models/household';
 
 const modelName = 'otherExpenses';
 
 class AdverseEffects extends React.Component {
+  setExpenseValues = () => {
+    const { formik } = this.props;
+    const { values } = formik;;
+
+    const expenseForReview = Object.entries(values.impact.otherExpenses).reduce((memo, [key, value]) => ({
+      ...memo,
+      [key]: {
+        applicable: true,
+        value: value.value || '0',
+      }
+    }), {});
+
+    return {
+      impact: {
+        ...values.impact,
+        otherExpenses: expenseForReview
+      }
+    };
+  }
+
   render() {
-    const { handleChange, sectionName, registerStep, t } = this.props;
+    const { handleChange, sectionName, registerStep, t, formik } = this.props;
+    const { impact, disasters, basicInfo } = formik.values;
+    const disaster = getDisaster(disasters, basicInfo.disasterIndex);
 
     return (
-      <Wizard.Context>
-        {({ impact, disasters, basicInfo }) => {
-          const disaster = getDisaster(disasters, basicInfo.disasterIndex);
-
-          return (
-            <Wizard.Step
-              header={t(`${buildNestedKey(sectionName, 'header')}`)}
-              registerStep={registerStep}
-              modelName={modelName}
-            >
-              <YesNoField
-                labelText={t('impact.buyFood.label', {
-                  benefitStartDate: disaster.benefit_begin_date,
-                  benefitEndDate: disaster.benefit_end_date
-                })}
-                name="impact.buyFood"
-                onChange={handleChange}
-              />
-              <YesNoField
-                labelText={t('impact.lostOrInaccessibleIncome.label')}
-                name="impact.lostOrInaccessibleIncome"
-                onChange={handleChange}
-              />
-              <YesNoField
-                labelText={t('impact.inaccessibleMoney.label')}
-                name="impact.inaccessibleMoney"
-                onChange={handleChange}
-              />
-              <FormikFieldGroup
-                labelText={t(buildNestedKey(sectionName, modelName, 'label'), {
-                  benefitStartDate: disaster.benefit_begin_date,
-                  benefitEndDate: disaster.benefit_end_date
-                })}
-                onChange={handleChange}
-                Component={ComboField}
-                fieldGroupClassname="margin-y-0"
-                fields={
-                  Object.entries(impact.otherExpenses).map(([name, values]) => {
-                    return {
-                      prefix: '$',
-                      type: 'checkbox',
-                      comboName: buildNestedKey(sectionName, modelName, name, 'value'),
-                      name: buildNestedKey(sectionName, modelName, name, 'applicable'),
-                      onChange: handleChange,
-                      labelText: t(buildNestedKey(sectionName, modelName, name)),
-                      quietLabel: true,
-                      explanation: t(buildNestedKey(sectionName, modelName, 'explanation')),
-                    }
-                  })
-                }
-              />
-              <FormikField
-                labelText={t(buildNestedKey(sectionName, modelName, 'none'))}
-                name={buildNestedKey(sectionName, 'noOtherExpenses')}
-                type="checkbox"
-                onChange={handleChange}
-              />
-            </Wizard.Step>
-          )
-        }}
-      </Wizard.Context>
+      <Wizard.Step
+        header={t(`${buildNestedKey(sectionName, 'header')}`)}
+        registerStep={registerStep}
+        modelName={modelName}
+        onNext={this.setExpenseValues}
+      >
+        <YesNoField
+          labelText={t('impact.buyFood.label', {
+            benefitStartDate: disaster.benefit_begin_date,
+            benefitEndDate: disaster.benefit_end_date
+          })}
+          name="impact.buyFood"
+          onChange={handleChange}
+        />
+        <YesNoField
+          labelText={t('impact.lostOrInaccessibleIncome.label')}
+          name="impact.lostOrInaccessibleIncome"
+          onChange={handleChange}
+        />
+        <YesNoField
+          labelText={t('impact.inaccessibleMoney.label')}
+          name="impact.inaccessibleMoney"
+          onChange={handleChange}
+        />
+        <FormikFieldGroup
+          labelText={t(buildNestedKey(sectionName, modelName, 'label'), {
+            benefitStartDate: disaster.benefit_begin_date,
+            benefitEndDate: disaster.benefit_end_date
+          })}
+          onChange={handleChange}
+          Component={ComboField}
+          fieldGroupClassname="margin-y-0"
+          fields={
+            Object.entries(impact.otherExpenses).map(([name, values]) => {
+              return {
+                prefix: '$',
+                type: 'checkbox',
+                comboName: buildNestedKey(sectionName, modelName, name, 'value'),
+                name: buildNestedKey(sectionName, modelName, name, 'applicable'),
+                onChange: handleChange,
+                labelText: t(buildNestedKey(sectionName, modelName, name)),
+                quietLabel: true,
+                explanation: t(buildNestedKey(sectionName, modelName, 'explanation')),
+              }
+            })
+          }
+        />
+        <FormikField
+          labelText={t(buildNestedKey(sectionName, modelName, 'none'))}
+          name={buildNestedKey(sectionName, 'noOtherExpenses')}
+          type="checkbox"
+          onChange={handleChange}
+        />
+      </Wizard.Step>
     )
   }
 }
 
 export { AdverseEffects }
-export default withLocale(AdverseEffects);
+export default connect(withLocale(AdverseEffects));


### PR DESCRIPTION
* Since the review section doesn't use the checkboxes, the validations
that we wrote for the main app wont be usuable in the review section.
The user cant go back to a previous page, so we can safely toggle each
of the checkboxes to applicable and set a value of zero, allowing for
the same validations to run in both the impact and review sections