### PR TITLE
Move `EDIT` action to review state chart

### DIFF
--- a/src/components/snapshot-review/index.js
+++ b/src/components/snapshot-review/index.js
@@ -27,7 +27,7 @@ class SnapshotReview extends React.Component {
     });
   }
 
-  renderReviewSections = ({ handleChange, resetForm, submitCount, isSubmitting, values, errors }) => {
+  renderReviewSections = ({ handleChange, resetForm, submitCount, isSubmitting, values, errors, handleSubmit }) => {
     const { t } = this.props;
     const disable = submitCount && (
       Object.keys(errors).length ||
@@ -41,7 +41,7 @@ class SnapshotReview extends React.Component {
     };
 
     return (
-      <Form>
+      <Form onSubmit={handleSubmit}>
         <BasicInfoReview
           title={t('review.sections.info')}
           {...extraProps}

--- a/src/fsm-config.js
+++ b/src/fsm-config.js
@@ -43,6 +43,11 @@ const initialState = () => {
     previousStep: '',
     previousSection: '',
     errors: '',
+    disasters: disaster(),
+    meta: {
+      loading: undefined
+    },
+    config: config(),
     /**
      * totalSteps refers to the number of sections a user will move through
      * while filling out the form. It doesn't necessarily reflect
@@ -52,11 +57,6 @@ const initialState = () => {
      * but is not exposed to the user. Therefore, it is not included in the total
      * number of steps
      */
-    disasters: disaster(),
-    meta: {
-      loading: undefined
-    },
-    config: config(),
     totalSteps: 6,
   };
   let state;
@@ -648,8 +648,26 @@ const reviewChart = {
       },
       on: {
         ...formNextHandler('#submit'),
+        EDIT: 'edit'
       }
-    }
+    },
+    edit: {
+      internal: true,
+      onEntry: [
+        () => console.log('executing edit actions'),
+        'persist',
+        assign((_, event) => {
+          const { type, ...rest } = event;
+
+          return {
+            ...rest
+          };
+        })
+      ],
+      on: {
+        ...formNextHandler('#submit'),
+      }
+    },
   }
 };
 
@@ -742,28 +760,11 @@ const formStateConfig = {
         },
       }
     },
-    edit: {
-      internal: true,
-      onEntry: [
-        () => console.log('executing edit actions'),
-        'persist',
-        assign((_, event) => {
-          const { type, ...rest } = event;
-
-          return {
-            ...rest
-          };
-        })
-      ],
-    }
   },
   on: {
     QUIT: {
       target: '.quit',
     },
-    EDIT: {
-      target: '.edit'
-    }
   }
 };
 


### PR DESCRIPTION
* Edit only occurs here
* Adds `NEXT` event handler to edit so form can submit properly
following an edit