### PR TITLE
Hide add job / household member buttons in review step

### DIFF
--- a/src/components/review-subsection/index.js
+++ b/src/components/review-subsection/index.js
@@ -4,6 +4,8 @@ import classnames from 'classnames';
 import withLocale from 'components/with-locale';
 import Button from 'components/button';
 
+const SCROLL_OFFSET_PADDING = 40;
+
 class ReviewSubSection extends React.Component {
   static propTypes = {
     onEdit: PropTypes.func.isRequired,
@@ -45,10 +47,11 @@ class ReviewSubSection extends React.Component {
 
   handleUpdate = () => {
     const updated = this.props.onUpdate();
+    const scrollY = Math.abs(this.ref.current.offsetTop) - SCROLL_OFFSET_PADDING;
 
     if (updated) {
       this.setState({ editing: false });
-      window.scrollTo(0, Math.abs(this.ref.current.offsetTop));
+      window.scrollTo(0, scrollY > 0 ? scrollY : 0);
     }
   }
 

--- a/src/components/review/household.js
+++ b/src/components/review/household.js
@@ -198,13 +198,16 @@ class HouseholdReview extends React.Component {
                   );
                 }}
               />
-              <Button
-                disabled={!isAffirmative(editing)}
-                type="button"
-                onClick={this.handleAddMember}
-              >
-                { t('review.addMember') }
-              </Button>
+              {
+                !editing ? null :
+                <Button
+                  disabled={!isAffirmative(editing)}
+                  type="button"
+                  onClick={this.handleAddMember}
+                >
+                  { t('review.addMember') }
+                </Button>
+              }
             </ReviewTableCollection>
           );
         }}

--- a/src/components/review/income.js
+++ b/src/components/review/income.js
@@ -254,22 +254,24 @@ class IncomeReviewSection extends React.Component {
                           })
                         }
                       </ReviewTableCollection>
-                      <Button
-                        disabled={!isAffirmative(editing)}
-                        type="button"
-                        onClick={() => this.handleAddJob(memberIndex, member)}
-                        className="margin-y-4"
-                      >
-                        { t('review.addJob') }
-                      </Button>
                       {
                         editing ?
-                        <IncomeSourcesReviewForm
-                          handleChange={this.props.handleChange}
-                          t={t}
-                          memberIndex={memberIndex}
-                          incomeSources={income.incomeSources}
-                        /> :
+                        <React.Fragment>
+                          <Button
+                            disabled={!isAffirmative(editing)}
+                            type="button"
+                            onClick={() => this.handleAddJob(memberIndex, member)}
+                            className="margin-y-4"
+                          >
+                            { t('review.addJob') }
+                          </Button>
+                          <IncomeSourcesReviewForm
+                            handleChange={this.props.handleChange}
+                            t={t}
+                            memberIndex={memberIndex}
+                            incomeSources={income.incomeSources}
+                          />
+                        </React.Fragment> :
                         <ReviewTable
                           editing={editing}
                           primaryData={this.getPrimaryIncomeData(income)}

--- a/src/pages/form/steps/impact/index.js
+++ b/src/pages/form/steps/impact/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'formik';
 import withLocale from 'components/with-locale';
 import Wizard from 'components/wizard';
-import FormikField, { FormikFieldGroup } from 'components/formik-field';
+import { FormikFieldGroup } from 'components/formik-field';
 import YesNoField from 'components/yes-no-field';
 import ComboField from 'components/combo-field';
 import { buildNestedKey } from 'utils';


### PR DESCRIPTION
* Buttons only visible while user is in edit mode
* Also add a bit of padding to scroll top behavior in review section. now when
a user finishes editing, the browser will scroll slightly above the top of the review section element