### PR TITLE
Adds 'en' as the default language when app bootstraps

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -5,10 +5,12 @@ import { en, es } from './locales';
 let lng;
 
 try {
-  lng = JSON.parse(localStorage.getItem('dsnap-registration')).config.language;
+  const registrationCache = JSON.parse(localStorage.getItem('dsnap-registration'));
+  lng = registrationCache.config.language;
 } catch(e) {
   lng = 'en';
 }
+
 const resources = {
   en: {
     translation: en

--- a/src/models/config.js
+++ b/src/models/config.js
@@ -1,4 +1,4 @@
 export default () => ({
   useLocalStorage: null,
-  language: '',
+  language: 'en',
 });


### PR DESCRIPTION
    * This fixes a bug where the translation library recieves an invalid valid for the user's
    preferred language. This occurs when the user visits the homepage and a session is initiated,
    but the user does not select a preferred language. Since a language has never been saved, the
    translation library will try to load strings with an invalid language. This causes the user
    to see the translation lookup keys, instead of the translated values

